### PR TITLE
Fixes the .gitignore issue by removing the cache that the env file was kept in

### DIFF
--- a/api/.env.bash
+++ b/api/.env.bash
@@ -1,1 +1,0 @@
-export SRV_PASS='TXsvrGPXGevdaPoi'


### PR DESCRIPTION
I added the `.env.bash` file before I added it to the `.gitignore` and this meant that git kept tracking and pushing it so I have rotated the key - yet again. I have tested it and now the `.env.bash` file is not tracked by git.